### PR TITLE
Add project metadata

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,19 @@
+Change Log
+==========
+
+All notable changes to this project will be documented in this file.
+
+The format is based on `Keep a Changelog`_ and this project adheres to
+`Semantic Versioning`_.
+
+.. _Keep A Changelog: http://keepachangelog.com/
+.. _Semantic Versioning: http://semver.org/
+
+[Unreleased]
+------------
+
+Added
+~~~~~
+
+* Python project structure
+* Packaging metadata

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-MIT License
+The MIT License (MIT)
 
-Copyright (c) 2017 Shaarli Community
+Copyright (c) 2017 The Shaarli Community
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,4 @@
+python-shaarli-client
+=====================
+
+A Python 3 Command-Line Interface to interact with a Shaarli instance.

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Setup script for shaarli-client"""
+import codecs
+
+from setuptools import find_packages, setup
+
+
+def get_long_description():
+    """Reads the main README.rst to get the program's long description"""
+    with codecs.open('README.rst', 'r', 'utf-8') as f_readme:
+        return f_readme.read()
+
+
+setup(
+    name='shaarli-client',
+    version='0.1',
+    description='CLI to interact with a Shaarli instance',
+    long_description=get_long_description(),
+    author='The Shaarli Community',
+    maintainer='VirtualTam',
+    maintainer_email='virtualtam@flibidi.net',
+    license='MIT',
+    url='https://github.com/shaarli/python-shaarli-client',
+    keywords='bookmark bookmarking shaarli social',
+    packages=find_packages(exclude=['tests.*', 'tests']),
+    install_requires=[],
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Environment :: Console',
+        'Intended Audience :: Developers',
+        'Intended Audience :: End Users/Desktop',
+        'License :: OSI Approved :: MIT License',
+        'Natural Language :: English',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Topic :: Utilities',
+    ]
+)

--- a/shaarli_client/__init__.py
+++ b/shaarli_client/__init__.py
@@ -1,0 +1,1 @@
+"""shaarli-client"""


### PR DESCRIPTION
Relates to https://github.com/shaarli/Shaarli/issues/745

Added:
- CHANGELOG.rst
- README.rst
- setuptools entrypoint (setup.py)
- shaarli_client package

Changed:
- update LICENSE

Notes:
- only one package author can be specified
  https://bugs.python.org/issue6992
- reStructuredText is the standard markup format for Python projects

About setup.py:
- https://docs.python.org/3.6/distutils/setupscript.html
- https://packaging.python.org/distributing/
- https://pythonhosted.org/an_example_pypi_project/setuptools.html
- https://pypi.python.org/pypi?%3Aaction=list_classifiers

About distutils and setuptools:
- https://docs.python.org/3.6/library/distutils.html
- https://setuptools.readthedocs.io/en/latest/
- https://stackoverflow.com/questions/6344076/differences-between-distribute-distutils-setuptools-and-distutils2
- https://packaging.python.org/current/#packaging-tool-recommendations

About reStructuredText:
- http://docutils.sourceforge.net/index.html
- http://docutils.sourceforge.net/rst.html
- http://www.sphinx-doc.org/en/1.4.9/rest.html