### PR TITLE
client: add main parser and support for /api/v1/info

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,8 +9,8 @@ The format is based on `Keep a Changelog`_ and this project adheres to
 .. _Keep A Changelog: http://keepachangelog.com/
 .. _Semantic Versioning: http://semver.org/
 
-[Unreleased]
-------------
+`v0.1.0 <https://github.com/shaarli/python-shaarli-client/releases/tag/v0.1.0>`_ - [Unreleased]
+-----------------------------------------------------------------------------------------------
 
 Added
 ~~~~~
@@ -21,3 +21,6 @@ Added
 * Sphinx documentation
 * Tox configuration
 * Travis CI configuration
+* REST API client
+
+  * ``/api/v1/info``

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,10 +4,10 @@ skip=.git,.tox,docs
 
 [pycodestyle]
 count=True
-exclude=.git,.tox,docs,__pycache__
+exclude=.git,.tox,build,docs,__pycache__
 max-line-length=80
 statistics=True
 
 [pydocstyle]
-ignore=D105,D400,D401
-match-dir=(?!docs)[^\.].*
+ignore=D105,D203,D400,D401
+match-dir=(?!build|docs)[^\.].*

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,15 @@ setup(
     url='https://github.com/shaarli/python-shaarli-client',
     keywords='bookmark bookmarking shaarli social',
     packages=find_packages(exclude=['tests.*', 'tests']),
-    install_requires=[],
+    entry_points={
+        'console_scripts': [
+            'shaarli = shaarli_client.main:main',
+        ],
+    },
+    install_requires=[
+        'requests >= 2.10',
+        'requests-jwt >= 0.4'
+    ],
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Environment :: Console',

--- a/shaarli_client/__init__.py
+++ b/shaarli_client/__init__.py
@@ -1,5 +1,5 @@
 """shaarli-client"""
 __title__ = 'shaarli_client'
 __brief__ = 'CLI to interact with a Shaarli instance'
-__version__ = '0.1'
+__version__ = '0.1.0'
 __author__ = 'The Shaarli Community'

--- a/shaarli_client/main.py
+++ b/shaarli_client/main.py
@@ -1,0 +1,45 @@
+"""shaarli-client main CLI entrypoint"""
+import json
+from argparse import ArgumentParser
+
+from .v1 import ShaarliV1Client
+
+
+def main():
+    """Main CLI entrypoint"""
+    parser = ArgumentParser()
+    parser.add_argument(
+        'endpoint',
+        choices=['info'],
+        default='info',
+        help="REST API endpoint"
+    )
+    parser.add_argument(
+        '-u',
+        '--url',
+        help="Shaarli instance URL"
+    )
+    parser.add_argument(
+        '-s',
+        '--secret',
+        help="API secret"
+    )
+    parser.add_argument(
+        '--output',
+        choices=['json', 'pprint', 'text'],
+        default='json',
+        help="Output formatting"
+    )
+
+    args = parser.parse_args()
+    client = ShaarliV1Client(args.url, args.secret)
+
+    if args.endpoint == 'info':
+        response = client.info()
+
+    if args.output == 'json':
+        print(response.json())
+    elif args.output == 'pprint':
+        print(json.dumps(response.json(), sort_keys=True, indent=4))
+    elif args.output == 'text':
+        print(response.text)

--- a/shaarli_client/v1.py
+++ b/shaarli_client/v1.py
@@ -1,0 +1,30 @@
+"""Shaarli REST API v1 client"""
+import calendar
+import time
+
+import requests
+from requests_jwt import JWTAuth
+
+
+class ShaarliV1Client:
+    """Shaarli REST API v1 client"""
+
+    # pylint: disable=too-few-public-methods
+
+    def __init__(self, uri, secret):
+        """Client constructor"""
+        self.uri = uri
+        self.secret = secret
+        self.version = 1
+
+    def _request(self, method, endpoint, params):
+        """Send an HTTP request to this instance"""
+        auth = JWTAuth(self.secret, alg='HS512', header_format='Bearer %s')
+        auth.add_field('iat', lambda req: calendar.timegm(time.gmtime()))
+
+        endpoint_uri = '%s/api/v%d/%s' % (self.uri, self.version, endpoint)
+        return requests.request(method, endpoint_uri, auth=auth, params=params)
+
+    def info(self):
+        """Get information about this instance"""
+        return self._request('GET', 'info', {})


### PR DESCRIPTION
First PR with actual code inside! I've kept the parser as minimal as possible for now

Sample usage with virtualenv creation:

```bash
$ python3 -m venv ~/.virtualenvs/shaarli
$ source ~/.virtualenvs/shaarli/bin/activate
$ cd path/to/python-chaarli-client
$ python setup.py install
$ shaarli -u http://localhost/~user/shaarli -s ch4ng3m3 --output pprint info
{
    "global_counter": 1501,
    "private_counter": 5,
    "settings": {
        "default_private_links": false,
        "enabled_plugins": [
            "markdown",
            "archiveorg"
        ],
        "header_link": "?",
        "timezone": "UTC",
        "title": "Yay"
    }
}
```

---

Added:
- ShaarliV1Client class
    - uses `requests-jwt` as a JWT authentication provider
    - uses `requests` to perform HTTP requests
- main parser
- setuptools entrypoint

Changed:
- disable pydocstyle error 203 - 1 blank line required before class docstring
- let linters ignore the `build` directory
- set version code to `0.1.0`

See:
- https://shaarli.github.io/api-documentation/#links-instance-information
- http://docs.python-requests.org/en/master/
- https://requests-jwt.readthedocs.io/en/latest/
- https://docs.python.org/3.6/library/argparse.html
- https://setuptools.readthedocs.io/en/latest/setuptools.html#automatic-script-creation