### PR TITLE
client: add support for api/v1/links, automate parser generation

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,7 @@ Added
 * Sphinx documentation
 * Tox configuration
 * Travis CI configuration
-* REST API client
+* REST API client:
 
   * ``/api/v1/info``
+  * ``/api/v1/links``

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,5 +9,5 @@ max-line-length=80
 statistics=True
 
 [pydocstyle]
-ignore=D105,D203,D400,D401
+ignore=D105,D203,D213,D400,D401
 match-dir=(?!build|docs)[^\.].*

--- a/shaarli_client/client/__init__.py
+++ b/shaarli_client/client/__init__.py
@@ -1,2 +1,2 @@
 """Shaarli REST API clients"""
-from .v1 import ShaarliV1Client
+from .v1 import InvalidEndpointParameters, ShaarliV1Client

--- a/shaarli_client/client/v1.py
+++ b/shaarli_client/client/v1.py
@@ -9,13 +9,40 @@ from requests_jwt import JWTAuth
 class ShaarliV1Client:
     """Shaarli REST API v1 client"""
 
-    # pylint: disable=too-few-public-methods
+    endpoints = {
+        'get-info': {
+            'path': 'info',
+            'method': 'GET',
+            'help': "Get information about this instance",
+            'params': None,
+        },
+    }
 
     def __init__(self, uri, secret):
         """Client constructor"""
         self.uri = uri
         self.secret = secret
         self.version = 1
+
+    @classmethod
+    def _retrieve_http_params(cls, args):
+        """Retrieve REST HTTP parameters from an Argparse Namespace
+
+        This is done by introspecing the parsed arguments with reference to
+        the client's endpoint metadata.
+        """
+        endpoint = cls.endpoints[args.endpoint_name]
+
+        if not endpoint.get('params'):
+            return (endpoint['method'], endpoint['path'], {})
+
+        params = {
+            param: getattr(args, param)
+            for param in endpoint.get('params').keys()
+            if hasattr(args, param)
+        }
+
+        return (endpoint['method'], endpoint['path'], params)
 
     def _request(self, method, endpoint, params):
         """Send an HTTP request to this instance"""
@@ -25,6 +52,10 @@ class ShaarliV1Client:
         endpoint_uri = '%s/api/v%d/%s' % (self.uri, self.version, endpoint)
         return requests.request(method, endpoint_uri, auth=auth, params=params)
 
-    def info(self):
+    def request(self, args):
+        """Send a parameterized request to this instance"""
+        return self._request(* self._retrieve_http_params(args))
+
+    def get_info(self):
         """Get information about this instance"""
         return self._request('GET', 'info', {})

--- a/shaarli_client/client/v1.py
+++ b/shaarli_client/client/v1.py
@@ -6,6 +6,19 @@ import requests
 from requests_jwt import JWTAuth
 
 
+class InvalidEndpointParameters(Exception):
+    """Raised when unauthorized endpoint parameters are used"""
+
+    def __init__(self, endpoint_name, parameters):
+        """Custom exception message"""
+        super(InvalidEndpointParameters, self).__init__(
+            "Invalid parameters for endpoint '%s': %s" % (
+                endpoint_name,
+                ", ".join(parameters)
+            )
+        )
+
+
 class ShaarliV1Client:
     """Shaarli REST API v1 client"""
 
@@ -23,6 +36,21 @@ class ShaarliV1Client:
         self.uri = uri
         self.secret = secret
         self.version = 1
+
+    @classmethod
+    def _check_endpoint_params(cls, endpoint_name, params):
+        """Check parameters are allowed for a given endpoint"""
+        if not params:
+            return
+
+        invalid_parameters = list()
+
+        for param in params.keys():
+            if param not in cls.endpoints[endpoint_name]['params'].keys():
+                invalid_parameters.append(param)
+
+        if invalid_parameters:
+            raise InvalidEndpointParameters(endpoint_name, invalid_parameters)
 
     @classmethod
     def _retrieve_http_params(cls, args):

--- a/shaarli_client/main.py
+++ b/shaarli_client/main.py
@@ -38,6 +38,7 @@ def main():
 
     try:
         response = ShaarliV1Client(args.url, args.secret).request(args)
+        print(response.url)
     except KeyError:
         parser.print_help()
         sys.exit(1)

--- a/shaarli_client/main.py
+++ b/shaarli_client/main.py
@@ -1,19 +1,15 @@
 """shaarli-client main CLI entrypoint"""
 import json
+import sys
 from argparse import ArgumentParser
 
 from .client import ShaarliV1Client
+from .utils import generate_all_endpoints_parsers
 
 
 def main():
     """Main CLI entrypoint"""
     parser = ArgumentParser()
-    parser.add_argument(
-        'endpoint',
-        choices=['info'],
-        default='info',
-        help="REST API endpoint"
-    )
     parser.add_argument(
         '-u',
         '--url',
@@ -31,11 +27,20 @@ def main():
         help="Output formatting"
     )
 
-    args = parser.parse_args()
-    client = ShaarliV1Client(args.url, args.secret)
+    subparsers = parser.add_subparsers(
+        dest='endpoint_name',
+        help="REST API endpoint"
+    )
 
-    if args.endpoint == 'info':
-        response = client.info()
+    generate_all_endpoints_parsers(subparsers, ShaarliV1Client.endpoints)
+
+    args = parser.parse_args()
+
+    try:
+        response = ShaarliV1Client(args.url, args.secret).request(args)
+    except KeyError:
+        parser.print_help()
+        sys.exit(1)
 
     if args.output == 'json':
         print(response.json())

--- a/shaarli_client/utils.py
+++ b/shaarli_client/utils.py
@@ -1,0 +1,26 @@
+"""Utilities"""
+
+
+def generate_endpoint_parser(subparsers, ep_name, ep_metadata):
+    """Generate a subparser and arguments from an endpoint dictionary"""
+    ep_parser = subparsers.add_parser(ep_name, help=ep_metadata['help'])
+
+    if not ep_metadata.get('params'):
+        return ep_parser
+
+    for param, attributes in sorted(ep_metadata['params'].items()):
+        ep_parser.add_argument(
+            '--%s' % param,
+            choices=attributes.get('choices'),
+            help=attributes.get('help'),
+            nargs=attributes.get('nargs'),
+            type=attributes.get('type')
+        )
+
+    return ep_parser
+
+
+def generate_all_endpoints_parsers(subparsers, endpoints):
+    """Generate all endpoints' subparsers from an endpoints dict"""
+    for ep_name, ep_metadata in endpoints.items():
+        generate_endpoint_parser(subparsers, ep_name, ep_metadata)

--- a/shaarli_client/utils.py
+++ b/shaarli_client/utils.py
@@ -11,6 +11,7 @@ def generate_endpoint_parser(subparsers, ep_name, ep_metadata):
     for param, attributes in sorted(ep_metadata['params'].items()):
         ep_parser.add_argument(
             '--%s' % param,
+            action=attributes.get('action'),
             choices=attributes.get('choices'),
             help=attributes.get('help'),
             nargs=attributes.get('nargs'),

--- a/tests/client/test_v1.py
+++ b/tests/client/test_v1.py
@@ -1,16 +1,41 @@
 """Tests for Shaarli REST API v1 client"""
 # pylint: disable=invalid-name,protected-access
+from argparse import Namespace
 from unittest import mock
 
-from shaarli_client.client import ShaarliV1Client
+from shaarli_client.client import InvalidEndpointParameters, ShaarliV1Client
 
 SHAARLI_URL = 'http://domain.tld/shaarli/'
 SHAARLI_SECRET = 's3kr37!'
 
 
+def test_invalid_endpoint_parameters_exception():
+    """Custom exception formatting"""
+    exc = InvalidEndpointParameters('post-dummy', ['param1', 'param2'])
+    assert str(exc) == \
+        "Invalid parameters for endpoint 'post-dummy': param1, param2"
+
+
 def test_constructor():
     """Instantiate a new client"""
     ShaarliV1Client(SHAARLI_URL, SHAARLI_SECRET)
+
+
+def test_check_endpoint_params_none():
+    """Check parameters - none passed"""
+    ShaarliV1Client._check_endpoint_params('get-info', None)
+
+
+def test_check_endpoint_params_empty():
+    """Check parameters - empty dict passed"""
+    ShaarliV1Client._check_endpoint_params('get-info', {})
+
+
+def test_retrieve_http_params_get_info():
+    """Retrieve REST parameters from an Argparse Namespace - GET /info"""
+    args = Namespace(endpoint_name='get-info')
+    assert ShaarliV1Client._retrieve_http_params(args) == \
+        ('GET', 'info', {})
 
 
 @mock.patch('requests.request')

--- a/tests/client/test_v1.py
+++ b/tests/client/test_v1.py
@@ -3,6 +3,8 @@
 from argparse import Namespace
 from unittest import mock
 
+import pytest
+
 from shaarli_client.client import InvalidEndpointParameters, ShaarliV1Client
 
 SHAARLI_URL = 'http://domain.tld/shaarli/'
@@ -31,11 +33,36 @@ def test_check_endpoint_params_empty():
     ShaarliV1Client._check_endpoint_params('get-info', {})
 
 
-def test_retrieve_http_params_get_info():
-    """Retrieve REST parameters from an Argparse Namespace - GET /info"""
-    args = Namespace(endpoint_name='get-info')
-    assert ShaarliV1Client._retrieve_http_params(args) == \
-        ('GET', 'info', {})
+def test_check_endpoint_params_ok():
+    """Check parameters - valid params passed"""
+    ShaarliV1Client._check_endpoint_params(
+        'get-links',
+        {'offset': 3, 'limit': 100}
+    )
+
+
+def test_check_endpoint_params_nok():
+    """Check parameters - invalid params passed"""
+    with pytest.raises(InvalidEndpointParameters) as exc:
+        ShaarliV1Client._check_endpoint_params(
+            'get-links',
+            {'get': 27, 'forget': 31}
+        )
+    assert "'get-links':" in str(exc.value)
+    assert 'get' in str(exc.value)
+    assert 'forget' in str(exc.value)
+
+
+def test_check_endpoint_params_nok_mixed():
+    """Check parameters - valid & invalid params passed"""
+    with pytest.raises(InvalidEndpointParameters) as exc:
+        ShaarliV1Client._check_endpoint_params(
+            'get-links',
+            {'offset': 200, 'preset': 27, 'headset': 31}
+        )
+    assert "'get-links':" in str(exc.value)
+    assert 'headset' in str(exc.value)
+    assert 'preset' in str(exc.value)
 
 
 @mock.patch('requests.request')
@@ -48,3 +75,44 @@ def test_get_info_uri(request):
         auth=mock.ANY,
         params={}
     )
+
+
+@mock.patch('requests.request')
+def test_get_links_uri(request):
+    """Ensure the proper endpoint URI is accessed"""
+    ShaarliV1Client(SHAARLI_URL, SHAARLI_SECRET).get_links({})
+    request.assert_called_once_with(
+        'GET',
+        '%s/api/v1/links' % SHAARLI_URL,
+        auth=mock.ANY,
+        params={}
+    )
+
+
+def test_retrieve_http_params_get_info():
+    """Retrieve REST parameters from an Argparse Namespace - GET /info"""
+    args = Namespace(endpoint_name='get-info')
+    assert ShaarliV1Client._retrieve_http_params(args) == \
+        ('GET', 'info', {})
+
+
+def test_retrieve_http_params_get_links():
+    """Retrieve REST parameters from an Argparse Namespace - GET /links"""
+    args = Namespace(
+        endpoint_name='get-links',
+        offset=42,
+        limit='all',
+        visibility='public'
+    )
+    assert ShaarliV1Client._retrieve_http_params(args) == \
+        ('GET', 'links', {'offset': 42, 'limit': 'all', 'visibility': 'public'})
+
+
+def test_retrieve_http_params_get_links_searchterm():
+    """Retrieve REST parameters from an Argparse Namespace - GET /links"""
+    args = Namespace(
+        endpoint_name='get-links',
+        searchterm='gimme+some+results'
+    )
+    assert ShaarliV1Client._retrieve_http_params(args) == \
+        ('GET', 'links', {'searchterm': 'gimme+some+results'})

--- a/tests/client/test_v1.py
+++ b/tests/client/test_v1.py
@@ -1,4 +1,5 @@
 """Tests for Shaarli REST API v1 client"""
+# pylint: disable=invalid-name,protected-access
 from unittest import mock
 
 from shaarli_client.client import ShaarliV1Client
@@ -15,7 +16,7 @@ def test_constructor():
 @mock.patch('requests.request')
 def test_get_info_uri(request):
     """Ensure the proper endpoint URI is accessed"""
-    ShaarliV1Client(SHAARLI_URL, SHAARLI_SECRET).info()
+    ShaarliV1Client(SHAARLI_URL, SHAARLI_SECRET).get_info()
     request.assert_called_once_with(
         'GET',
         '%s/api/v1/info' % SHAARLI_URL,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -63,6 +63,7 @@ def test_generate_endpoint_parser_single_param(addargument):
         # param1
         mock.call(
             '--param1',
+            action=None,
             choices=None,
             help="First param",
             nargs=None,
@@ -106,10 +107,10 @@ def test_generate_endpoint_parser_multi_param(addargument):
                   default=mock.ANY, help=mock.ANY),
 
         # param1
-        mock.call('--param1', choices=None, help="First param",
-                  nargs=None, type=int),
+        mock.call('--param1', action=None, choices=None,
+                  help="First param", nargs=None, type=int),
 
         # param2
-        mock.call('--param2', choices=['a', 'b', 'c'],
+        mock.call('--param2', action=None, choices=['a', 'b', 'c'],
                   help="Second param", nargs='+', type=None)
     ])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,115 @@
+"""Tests for Shaarli client utilities"""
+# pylint: disable=invalid-name
+from argparse import ArgumentParser
+from unittest import mock
+
+from shaarli_client.utils import generate_endpoint_parser
+
+
+@mock.patch('argparse.ArgumentParser.add_argument')
+def test_generate_endpoint_parser_noparam(addargument):
+    """Generate a parser from endpoint metadata - no params"""
+    name = 'put-stuff'
+    metadata = {
+        'path': 'stuff',
+        'method': 'PUT',
+        'help': "Changes stuff",
+        'params': {},
+    }
+    parser = ArgumentParser()
+    subparsers = parser.add_subparsers()
+
+    generate_endpoint_parser(subparsers, name, metadata)
+
+    addargument.assert_has_calls([
+        # first helper for the main parser
+        mock.call('-h', '--help', action='help',
+                  default=mock.ANY, help=mock.ANY),
+
+        # second helper for the 'put-stuff' subparser
+        mock.call('-h', '--help', action='help',
+                  default=mock.ANY, help=mock.ANY)
+    ])
+
+
+@mock.patch('argparse.ArgumentParser.add_argument')
+def test_generate_endpoint_parser_single_param(addargument):
+    """Generate a parser from endpoint metadata - single param"""
+    name = 'get-stuff'
+    metadata = {
+        'path': 'stuff',
+        'method': 'GET',
+        'help': "Gets stuff",
+        'params': {
+            'param1': {
+                'help': "First param",
+            },
+        },
+    }
+    parser = ArgumentParser()
+    subparsers = parser.add_subparsers()
+
+    generate_endpoint_parser(subparsers, name, metadata)
+
+    addargument.assert_has_calls([
+        # first helper for the main parser
+        mock.call('-h', '--help', action='help',
+                  default=mock.ANY, help=mock.ANY),
+
+        # second helper for the 'put-stuff' subparser
+        mock.call('-h', '--help', action='help',
+                  default=mock.ANY, help=mock.ANY),
+
+        # param1
+        mock.call(
+            '--param1',
+            choices=None,
+            help="First param",
+            nargs=None,
+            type=None
+        )
+    ])
+
+
+@mock.patch('argparse.ArgumentParser.add_argument')
+def test_generate_endpoint_parser_multi_param(addargument):
+    """Generate a parser from endpoint metadata - multiple params"""
+    name = 'get-stuff'
+    metadata = {
+        'path': 'stuff',
+        'method': 'GET',
+        'help': "Gets stuff",
+        'params': {
+            'param1': {
+                'help': "First param",
+                'type': int,
+            },
+            'param2': {
+                'choices': ['a', 'b', 'c'],
+                'help': "Second param",
+                'nargs': '+',
+            },
+        },
+    }
+    parser = ArgumentParser()
+    subparsers = parser.add_subparsers()
+
+    generate_endpoint_parser(subparsers, name, metadata)
+
+    addargument.assert_has_calls([
+        # first helper for the main parser
+        mock.call('-h', '--help', action='help',
+                  default=mock.ANY, help=mock.ANY),
+
+        # second helper for the 'put-stuff' subparser
+        mock.call('-h', '--help', action='help',
+                  default=mock.ANY, help=mock.ANY),
+
+        # param1
+        mock.call('--param1', choices=None, help="First param",
+                  nargs=None, type=int),
+
+        # param2
+        mock.call('--param2', choices=['a', 'b', 'c'],
+                  help="Second param", nargs='+', type=None)
+    ])


### PR DESCRIPTION
Suggested CLI usage:

```bash
$ shaarli [GLOBAL OPTIONS] <HTTP_METHOD>-<ENDPOINT> [ENDPOINT OPTIONS]

# e.g.:
$ shaarli -u URL -s SECRET --output pprint get-info
$ shaarli -u URL -s SECRET get-links --offset 36 --searchtags tag1 tag2 --limit all
```

---

https://shaarli.github.io/api-documentation/#links-links-collection-get

Added:
- api/v1/links endpoint support
- let the client hold endpoint metadata:
  - parser commands
  - API path
  - HTTP method
  - help
  - allowed parameters, when applicable
- parser <-> client utilities:
  - generate endpoint subparsers from client metadata
  - retrieve valid endpoint parameters from parsed data
- raise an Exception if invalid parameters are passed

Changed:
- cli: display the help if no endpoint is selected
- cli: refactor parser and argument definition
- pydocstyle: disable D213 - Multi-line docstring summary should start at the second line
     (conflicts with D212 - Multi-line docstring summary should start at the first line)

See:
- https://docs.python.org/3.5/library/argparse.html
- error handling:
  - https://docs.python.org/3/library/exceptions.html
  - https://stackoverflow.com/questions/1319615/proper-way-to-declare-custom-exceptions-in-modern-python
  - http://doc.pytest.org/en/latest/assert.html
- introspection:
  - https://docs.python.org/3.5/library/functions.html#getattr
  - https://docs.python.org/3.5/library/functions.html#hasattr
  - https://www.python.org/dev/peps/pep-0274/
  - https://stackoverflow.com/questions/14507591/python-dictionary-comprehension#14507637
- collections, tuples & unpacking:
  - https://docs.python.org/3/tutorial/controlflow.html#unpacking-argument-lists
  - https://docs.python.org/3.5/library/collections.html#collections.OrderedDict

---

![code-review-is-coming](https://cdn.meme.am/cache/instances/folder241/64512241.jpg)