### PR TITLE
docs: add PyPI release instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+all: clean dist
+
+clean:
+	@rm -rf build dist
+	@find . -name "*.pyc" -delete
+.PHONY: clean
+
+distclean:
+	@git clean -xdf
+.PHONY: distclean
+
+# Setuptools
+sdist:
+	@python setup.py sdist
+
+bdist_wheel:
+	@python setup.py bdist_wheel
+
+dist: sdist bdist_wheel
+
+install:
+	@python setup.py install
+
+# PyPI and TestPyPI
+release: clean dist
+	@twine upload dist/* -s -i $(IDENTITY)
+
+test_release: clean dist
+	@twine upload dist/* -r testpypi --skip-existing -s -i $(IDENTITY)
+
+# Sphinx documentation
+docs: clean
+	@tox -r -e docs

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,7 +19,12 @@ Added
 * Packaging metadata
 * Code quality checking (lint)
 * Test coverage
-* Sphinx documentation
+* Sphinx documentation:
+
+  * user - installation, usage
+  * developer - testing, releasing
+
+* Makefile
 * Tox configuration
 * Travis CI configuration
 * REST API client:

--- a/docs/developer/gpg.rst
+++ b/docs/developer/gpg.rst
@@ -1,0 +1,120 @@
+GnuPG
+=====
+
+Introduction
+------------
+
+PGP and GPG
+~~~~~~~~~~~
+
+`Gnu Privacy Guard`_ (GnuPG) is an Open Source implementation of the
+`Pretty Good Privacy`_ (OpenPGP) specification.
+Its main purposes are digital authentication, signature and encryption.
+
+It is often used by the `FLOSS`_ community to verify:
+
+* Linux package signatures: Debian `SecureApt`_, ArchLinux `Master Keys`_
+* `SCM`_ releases & maintainer identity
+
+.. _FLOSS: https://en.wikipedia.org/wiki/Free_and_open-source_software
+.. _Gnu Privacy Guard: https://gnupg.org/
+.. _Master Keys: https://www.archlinux.org/master-keys/
+.. _Pretty Good Privacy: https://en.wikipedia.org/wiki/Pretty_Good_Privacy#OpenPGP
+.. _SCM: https://en.wikipedia.org/wiki/Revision_control
+.. _SecureApt: https://wiki.debian.org/SecureApt
+
+Trust
+~~~~~
+
+To quote Phil Pennock, the author of the `SKS`_ key `server <http://sks.spodhuis.org/>`_:
+
+.. pull-quote::
+
+   You MUST understand that presence of data in the keyserver (pools) in no way connotes trust.
+   Anyone can generate a key, with any name or email address, and upload it.
+   All security and trust comes from evaluating security at the “object level”,
+   via PGP Web-Of-Trust signatures.
+   This keyserver makes it possible to retrieve keys, looking them up via various indices,
+   but the collection of keys in this public pool is KNOWN to contain malicious
+   and fraudulent keys.
+   It is the common expectation of server operators that users understand this
+   and use software which, like all known common OpenPGP implementations,
+   evaluates trust accordingly.
+   This expectation is so common that it is not normally explicitly stated.
+
+Trust can be gained by having your key signed by other people
+(and signing their keys back, too :-) ), for instance during `key signing parties`_:
+
+* `The Keysigning Party HOWTO
+  <http://www.cryptnet.net/fdp/crypto/keysigning_party/en/keysigning_party.html>`_
+* `Web of Trust
+  <https://en.wikipedia.org/wiki/Web_of_trust>`_
+
+.. _key signing parties: https://en.wikipedia.org/wiki/Key_signing_party
+.. _SKS: https://bitbucket.org/skskeyserver/sks-keyserver/wiki/Home
+
+Generate a GPG key
+------------------
+
+* `Generating a GPG key for Git tagging <http://stackoverflow.com/a/16725717>`_ (StackOverflow)
+* `Generating a GPG key <https://help.github.com/articles/generating-a-gpg-key/>`_ (GitHub)
+
+``gpg`` - provide identity information
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   $ gpg --gen-key
+
+   gpg (GnuPG) 2.1.6; Copyright (C) 2015 Free Software Foundation, Inc.
+   This is free software: you are free to change and redistribute it.
+   There is NO WARRANTY, to the extent permitted by law.
+
+   Note: Use "gpg2 --full-gen-key" for a full featured key generation dialog.
+
+   GnuPG needs to construct a user ID to identify your key.
+
+   Real name: Marvin the Paranoid Android
+   Email address: marvin@h2g2.net
+   You selected this USER-ID:
+       "Marvin the Paranoid Android <marvin@h2g2.net>"
+
+   Change (N)ame, (E)mail, or (O)kay/(Q)uit? o
+   We need to generate a lot of random bytes. It is a good idea to perform
+   some other action (type on the keyboard, move the mouse, utilize the
+   disks) during the prime generation; this gives the random number
+   generator a better chance to gain enough entropy.
+
+``gpg`` - entropy interlude
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+At this point, you will:
+
+* be prompted for a secure password to protect your key
+  (the input method will depend on your Desktop Environment and configuration)
+* be asked to use your machine's input devices (mouse, keyboard, etc.)
+  to generate random entropy; this step *may take some time*
+
+``gpg`` - key creation confirmation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   gpg: key A9D53A3E marked as ultimately trusted
+   public and secret key created and signed.
+
+   gpg: checking the trustdb
+   gpg: 3 marginal(s) needed, 1 complete(s) needed, PGP trust model
+   gpg: depth: 0  valid:   2  signed:   0  trust: 0-, 0q, 0n, 0m, 0f, 2u
+   pub   rsa2048/A9D53A3E 2015-07-31
+   Key fingerprint = AF2A 5381 E54B 2FD2 14C4  A9A3 0E35 ACA4 A9D5 3A3E
+   uid       [ultimate] Marvin the Paranoid Android <marvin@h2g2.net>
+   sub   rsa2048/8C0EACF1 2015-07-31
+
+``gpg`` - submit your public key to a PGP server
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   $ gpg --keyserver pgp.mit.edu --send-keys A9D53A3E
+   gpg: sending key A9D53A3E to hkp server pgp.mit.edu

--- a/docs/developer/pypirc
+++ b/docs/developer/pypirc
@@ -1,0 +1,13 @@
+[distutils]
+index-servers=
+    pypi
+    testpypi
+
+[pypi]
+repository = https://pypi.python.org/pypi
+username = <PyPI username>
+
+[testpypi]
+repository = https://testpypi.python.org/pypi
+username = <TestPyPI username>
+password = <TestPyPI password>

--- a/docs/developer/releasing.rst
+++ b/docs/developer/releasing.rst
@@ -1,4 +1,93 @@
 Releasing
 =========
 
-*TODO - write PyPI release instructions here*
+Reference:
+
+* `Python Packaging User Guide`_
+
+  * `Packaging and Distributing Projects`_
+
+* `TestPyPI Configuration`_
+
+Environment and requirements
+----------------------------
+
+`twine`_ is used to register Python projects to `PyPI`_ and upload release artifacts:
+
+* ``PKG-INFO``: project description and metadata defined in ``setup.py``
+* ``sdist``: source distribution tarball
+* ``wheel``: binary release that can be platform- and interpreter- dependent
+
+Development libraries need to be installed to build the project and upload artifacts
+(see :doc:`testing`):
+
+.. code-block:: bash
+
+   (shaarli) $ pip install -r requirements/dev.txt
+
+PyPI and TestPyPI configuration
+-------------------------------
+
+.. danger::
+
+   Once uploaded, artifacts cannot be overwritten. If something goes wrong while
+   releasing artifacts, you will need to bump the release version code and issue
+   a new release.
+
+   It is safer to test the release process on `TestPyPI`_ first; it provides
+   a sandbox to experiment with project registration and upload.
+
+``~/.pypirc``
+~~~~~~~~~~~~~
+
+.. literalinclude:: pypirc
+   :language: ini
+
+
+Releasing ``shaarli-client``
+----------------------------
+
+Checklist
+~~~~~~~~~
+
+* install Python dependencies
+* setup PyPI and TestPyPI:
+
+  * create an account on both servers
+  * edit ``~/.pypirc``
+  * register the project on both servers
+
+* get a :doc:`gpg` key to sign the artifacts
+* double check project binaries and metadata
+* tag the new release
+* build and upload the release on TestPyPI
+* build and upload the release on PyPI
+
+.. tip::
+
+   A ``Makefile`` is provided for convenience, and allows to build, sign
+   and upload artifacts on both `PyPI`_ and `TestPyPI`_.
+
+TestPyPI
+~~~~~~~~
+
+.. code-block:: bash
+
+   (shaarli) $ export IDENTITY=<GPG key ID>
+   (shaarli) $ make test_release
+
+PyPI
+~~~~
+
+.. code-block:: bash
+
+   (shaarli) $ export IDENTITY=<GPG key ID>
+   (shaarli) $ make release
+
+
+.. _Packaging and Distributing Projects: https://packaging.python.org/distributing/
+.. _PyPI: https://pypi.python.org/pypi
+.. _Python Packaging User Guide: https://packaging.python.org
+.. _TestPyPI: https://testpypi.python.org/pypi
+.. _TestPyPI Configuration: https://wiki.python.org/moin/TestPyPI
+.. _twine: https://pypi.python.org/pypi/twine

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,7 @@ Command-line interface (CLI) to interact with a `Shaarli`_ instance.
 
    developer/testing
    developer/releasing
+   developer/gpg
 
 
 Indices and tables

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,3 +1,4 @@
 -r docs.txt
 -r tests.txt
 tox==2.5.0
+twine==1.8.1


### PR DESCRIPTION
Added:
- PyPI and TestPyPI server configuration + example
- Twine usage
- GnuPG setup (ported from https://github.com/shaarli/Shaarli/wiki/GnuPG-signature)
- Makefile for convenience