### PR TITLE
cli: read configuration from INI files

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ The format is based on `Keep a Changelog`_ and this project adheres to
 **Added:**
 
 * Add client parameter checks and error handling
+* Read instance information from a configuration file
 
 
 `v0.1.0 <https://github.com/shaarli/python-shaarli-client/releases/tag/v0.1.0>`_ - 2017-03-12

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,7 @@ Command-line interface (CLI) to interact with a `Shaarli`_ instance.
    :caption: User Documentation
 
    user/installation
+   user/configuration
    user/usage
    changelog
 

--- a/docs/user/client.ini
+++ b/docs/user/client.ini
@@ -1,0 +1,11 @@
+[shaarli]
+url = https://host.tld/shaarli
+secret = s3kr37!
+
+[shaarli:shaaplin]
+url = https://shaarli.shaapl.in
+secret = m0d3rn71m3s
+
+[shaarli:dev]
+url = http://localhost/shaarli
+secret = asdf1234

--- a/docs/user/configuration.rst
+++ b/docs/user/configuration.rst
@@ -1,0 +1,24 @@
+Configuration
+=============
+
+``shaarli-client`` loads information about Shaarli instances from a
+configuration file, located at:
+
+* ``~/.config/shaarli/client.ini`` (recommended)
+* ``~/.shaarli_client.ini``
+* ``shaarli_client.ini`` (in the current directory)
+* user-specified location, using the ``-c``/``--config`` flag
+
+Several Shaarli instances can be configured:
+
+``[shaarli]``
+   the default instance
+``[shaarli:<my-other-instance>]``
+   an additional instance that can be selected by passing the ``-i`` flag:
+   ``$ shaarli -i my-other-instance get-info``
+
+Example
+-------
+
+.. literalinclude:: client.ini
+   :language: ini

--- a/docs/user/usage.rst
+++ b/docs/user/usage.rst
@@ -13,7 +13,8 @@ The ``-h`` and ``--help`` flags allow to display help for any command or sub-com
 
    $ shaarli -h
 
-   usage: shaarli [-h] [-u URL] [-s SECRET] [--output {json,pprint,text}]
+   usage: shaarli [-h] [-c CONFIG] [-i INSTANCE] [-u URL] [-s SECRET]
+                  [--output {json,pprint,text}]
                   {get-info,get-links} ...
 
    positional arguments:
@@ -23,6 +24,10 @@ The ``-h`` and ``--help`` flags allow to display help for any command or sub-com
 
    optional arguments:
      -h, --help            show this help message and exit
+     -c CONFIG, --config CONFIG
+                           Configuration file
+     -i INSTANCE, --instance INSTANCE
+                           Shaarli instance (configuration alias)
      -u URL, --url URL     Shaarli instance URL
      -s SECRET, --secret SECRET
                            API secret
@@ -62,12 +67,14 @@ General syntax
    $ shaarli <global arguments> <endpoint> <endpoint arguments>
 
 
+.. note:: The following examples assume a :doc:`configuration` file is used
+
 GET info
 ~~~~~~~~
 
 .. code-block:: bash
 
-   $ shaarli -u https://host.tld/shaarli/ -s s3kr37 --output pprint get-info
+   $ shaarli --output pprint get-info
 
    {
        "global_counter": 1502,
@@ -90,7 +97,7 @@ GET links
 
 .. code-block:: bash
 
-   $ shaarli -u https://host.tld/shaarli/ -s s3kr37 --output pprint get-links --searchtags super hero
+   $ shaarli --output pprint get-links --searchtags super hero
 
    [
        {

--- a/shaarli_client/main.py
+++ b/shaarli_client/main.py
@@ -1,8 +1,11 @@
 """shaarli-client main CLI entrypoint"""
 import json
 import logging
+import os
 import sys
 from argparse import ArgumentParser
+from configparser import ConfigParser
+from pathlib import Path
 
 from .client import ShaarliV1Client
 from .utils import generate_all_endpoints_parsers
@@ -11,6 +14,16 @@ from .utils import generate_all_endpoints_parsers
 def main():
     """Main CLI entrypoint"""
     parser = ArgumentParser()
+    parser.add_argument(
+        '-c',
+        '--config',
+        help="Configuration file"
+    )
+    parser.add_argument(
+        '-i',
+        '--instance',
+        help="Shaarli instance (configuration alias)"
+    )
     parser.add_argument(
         '-u',
         '--url',
@@ -38,8 +51,9 @@ def main():
     args = parser.parse_args()
 
     try:
-        response = ShaarliV1Client(args.url, args.secret).request(args)
-        print(response.url)
+        url, secret = get_credentials(args)
+        response = ShaarliV1Client(url, secret).request(args)
+
     except (KeyError, TypeError, ValueError) as exc:
         logging.error(exc)
         parser.print_help()
@@ -51,3 +65,37 @@ def main():
         print(json.dumps(response.json(), sort_keys=True, indent=4))
     elif args.output == 'text':
         print(response.text)
+
+
+def get_credentials(args):
+    """Retrieve Shaarli authentication information"""
+    if args.url and args.secret:
+        # credentials passed as CLI arguments
+        logging.warning("Passing credentials as arguments is unsafe"
+                        " and should be used for debugging only")
+        return (args.url, args.secret)
+
+    config = ConfigParser()
+
+    if args.instance:
+        instance = 'shaarli:{}'.format(args.instance)
+    else:
+        instance = 'shaarli'
+
+    if args.config:
+        # user-specified configuration file
+        logging.info("Reading configuration from: %s", args.config)
+        with open(args.config, 'r') as f_config:
+            config.read_file(f_config)
+    else:
+        # load configuration from a list of possible locations
+        home = Path(os.path.expanduser('~'))
+        config_files = config.read([
+            home / '.config' / 'shaarli' / 'client.ini',
+            home / '.shaarli_client.ini',
+            'shaarli_client.ini'
+        ])
+        logging.info("Reading configuration from: %s",
+                     ', '.join([str(cfg) for cfg in config_files]))
+
+    return (config[instance]['url'], config[instance]['secret'])


### PR DESCRIPTION
Relates to https://github.com/shaarli/python-shaarli-client/issues/7

Added:
- Allow the user to supply a custom config file
- Look for a confg file in common locations
- Allow configuring several Shaarli instances

Changed:
- Display a warning when passing credentials from the CLI

See:
- https://docs.python.org/3.6/library/configparser.html
- https://docs.python.org/3.6/library/pathlib.html