### PR TITLE
cli: rename '--output' to '--format', default to 'pprint'

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,11 @@ The format is based on `Keep a Changelog`_ and this project adheres to
 * Add client parameter checks and error handling
 * Read instance information from a configuration file
 
+**Changed:**
+
+* CLI: rename ``--output`` to ``--format``
+* CLI: default to 'pprint' output format
+
 
 `v0.1.0 <https://github.com/shaarli/python-shaarli-client/releases/tag/v0.1.0>`_ - 2017-03-12
 ---------------------------------------------------------------------------------------------

--- a/docs/user/usage.rst
+++ b/docs/user/usage.rst
@@ -14,7 +14,7 @@ The ``-h`` and ``--help`` flags allow to display help for any command or sub-com
    $ shaarli -h
 
    usage: shaarli [-h] [-c CONFIG] [-i INSTANCE] [-u URL] [-s SECRET]
-                  [--output {json,pprint,text}]
+                  [--format {json,pprint,text}]
                   {get-info,get-links} ...
 
    positional arguments:
@@ -31,7 +31,7 @@ The ``-h`` and ``--help`` flags allow to display help for any command or sub-com
      -u URL, --url URL     Shaarli instance URL
      -s SECRET, --secret SECRET
                            API secret
-     --output {json,pprint,text}
+     --format {json,pprint,text}
                            Output formatting
 
 
@@ -74,7 +74,7 @@ GET info
 
 .. code-block:: bash
 
-   $ shaarli --output pprint get-info
+   $ shaarli get-info
 
    {
        "global_counter": 1502,
@@ -97,7 +97,7 @@ GET links
 
 .. code-block:: bash
 
-   $ shaarli --output pprint get-links --searchtags super hero
+   $ shaarli get-links --searchtags super hero
 
    [
        {

--- a/shaarli_client/main.py
+++ b/shaarli_client/main.py
@@ -35,9 +35,9 @@ def main():
         help="API secret"
     )
     parser.add_argument(
-        '--output',
+        '--format',
         choices=['json', 'pprint', 'text'],
-        default='json',
+        default='pprint',
         help="Output formatting"
     )
 
@@ -59,11 +59,11 @@ def main():
         parser.print_help()
         sys.exit(1)
 
-    if args.output == 'json':
+    if args.format == 'json':
         print(response.json())
-    elif args.output == 'pprint':
+    elif args.format == 'pprint':
         print(json.dumps(response.json(), sort_keys=True, indent=4))
-    elif args.output == 'text':
+    elif args.format == 'text':
         print(response.text)
 
 


### PR DESCRIPTION
Relates to https://github.com/shaarli/python-shaarli-client/issues/7
Relates to https://github.com/shaarli/python-shaarli-client/pull/15