### PR TITLE
API: POST /api/v1/links

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,7 @@ The format is based on `Keep a Changelog`_ and this project adheres to
 
 * CLI: rename ``--output`` to ``--format``
 * CLI: default to 'pprint' output format
+* CLI: improve endpoint-specific parser argument generation
 
 
 `v0.1.0 <https://github.com/shaarli/python-shaarli-client/releases/tag/v0.1.0>`_ - 2017-03-12

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,12 +16,17 @@ The format is based on `Keep a Changelog`_ and this project adheres to
 
 * Add client parameter checks and error handling
 * Read instance information from a configuration file
+* REST API client:
+
+  * ``POST api/v1/links``
 
 **Changed:**
 
-* CLI: rename ``--output`` to ``--format``
-* CLI: default to 'pprint' output format
-* CLI: improve endpoint-specific parser argument generation
+* CLI:
+
+  * rename ``--output`` to ``--format``
+  * default to 'pprint' output format
+  * improve endpoint-specific parser argument generation
 
 
 `v0.1.0 <https://github.com/shaarli/python-shaarli-client/releases/tag/v0.1.0>`_ - 2017-03-12
@@ -43,5 +48,5 @@ The format is based on `Keep a Changelog`_ and this project adheres to
 * Travis CI configuration
 * REST API client:
 
-  * ``/api/v1/info``
-  * ``/api/v1/links``
+  * ``GET /api/v1/info``
+  * ``GET /api/v1/links``

--- a/shaarli_client/utils.py
+++ b/shaarli_client/utils.py
@@ -9,14 +9,7 @@ def generate_endpoint_parser(subparsers, ep_name, ep_metadata):
         return ep_parser
 
     for param, attributes in sorted(ep_metadata['params'].items()):
-        ep_parser.add_argument(
-            '--%s' % param,
-            action=attributes.get('action'),
-            choices=attributes.get('choices'),
-            help=attributes.get('help'),
-            nargs=attributes.get('nargs'),
-            type=attributes.get('type')
-        )
+        ep_parser.add_argument('--%s' % param, **attributes)
 
     return ep_parser
 

--- a/tests/client/test_v1.py
+++ b/tests/client/test_v1.py
@@ -155,3 +155,45 @@ def test_retrieve_http_params_get_links_searchterm():
     )
     assert ShaarliV1Client._retrieve_http_params(args) == \
         ('GET', 'links', {'searchterm': 'gimme+some+results'})
+
+
+@mock.patch('requests.request')
+def test_post_links_uri(request):
+    """Ensure the proper endpoint URI is accessed"""
+    ShaarliV1Client(SHAARLI_URL, SHAARLI_SECRET).post_link({})
+    request.assert_called_once_with(
+        'POST',
+        '%s/api/v1/links' % SHAARLI_URL,
+        auth=mock.ANY,
+        json={}
+    )
+
+
+def test_retrieve_http_params_post_link():
+    """Retrieve REST parameters from an Argparse Namespace - POST /links"""
+    args = Namespace(
+        endpoint_name='post-link',
+        description="I am not a bookmark about a link.",
+        private=False,
+        tags=["nope", "4891"],
+        title="Ain't Talkin' 'bout Links",
+        url='https://aint.talkin.bout.lin.ks'
+    )
+    assert ShaarliV1Client._retrieve_http_params(args) == \
+        (
+            'POST',
+            'links',
+            {
+                'description': "I am not a bookmark about a link.",
+                'private': False,
+                'tags': ["nope", "4891"],
+                'title': "Ain't Talkin' 'bout Links",
+                'url': 'https://aint.talkin.bout.lin.ks'
+            }
+        )
+
+
+def test_retrieve_http_params_post_empty_link():
+    """Retrieve REST parameters from an Argparse Namespace - POST /links"""
+    args = Namespace(endpoint_name='post-link')
+    assert ShaarliV1Client._retrieve_http_params(args) == ('POST', 'links', {})

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -61,14 +61,7 @@ def test_generate_endpoint_parser_single_param(addargument):
                   default=mock.ANY, help=mock.ANY),
 
         # param1
-        mock.call(
-            '--param1',
-            action=None,
-            choices=None,
-            help="First param",
-            nargs=None,
-            type=None
-        )
+        mock.call('--param1', help="First param")
     ])
 
 
@@ -107,10 +100,9 @@ def test_generate_endpoint_parser_multi_param(addargument):
                   default=mock.ANY, help=mock.ANY),
 
         # param1
-        mock.call('--param1', action=None, choices=None,
-                  help="First param", nargs=None, type=int),
+        mock.call('--param1', help="First param", type=int),
 
         # param2
-        mock.call('--param2', action=None, choices=['a', 'b', 'c'],
-                  help="Second param", nargs='+', type=None)
+        mock.call('--param2', choices=['a', 'b', 'c'],
+                  help="Second param", nargs='+')
     ])


### PR DESCRIPTION
Relates to shaarli/Shaarli#742
See http://shaarli.github.io/api-documentation/#links-links-collection-post

Added:
- POST /api/v1/links to create a new link/note

Changed:
- improve endpoint-specific parser argument generation
- rename SearchFormatAction to TextFormatAction

---

Test snippet:

```shell
$ shaarli post-link --url http://i.like.trai.ns/$(date +%s) --title I like trains --tags trains railway --private --description Des cript ion
```