### PR TITLE
API: PUT /api/v1/links/<LINK_ID>

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,17 @@ The format is based on `Keep a Changelog`_ and this project adheres to
 `v0.3.0 <https://github.com/shaarli/python-shaarli-client/releases/tag/v0.3.0>`_ - UNPUBLISHED
 ----------------------------------------------------------------------------------------------
 
+**Added:**
+
+* CLI:
+
+  * Add support for endpoint resource(s)
+
+* REST API client:
+
+  * ``PUT api/v1/links/<LINK_ID>``
+
+
 `v0.2.0 <https://github.com/shaarli/python-shaarli-client/releases/tag/v0.2.0>`_ - 2017-04-09
 ---------------------------------------------------------------------------------------------
 

--- a/shaarli_client/utils.py
+++ b/shaarli_client/utils.py
@@ -5,6 +5,9 @@ def generate_endpoint_parser(subparsers, ep_name, ep_metadata):
     """Generate a subparser and arguments from an endpoint dictionary"""
     ep_parser = subparsers.add_parser(ep_name, help=ep_metadata['help'])
 
+    if ep_metadata.get('resource'):
+        ep_parser.add_argument('resource', **ep_metadata.get('resource'))
+
     if not ep_metadata.get('params'):
         return ep_parser
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -106,3 +106,36 @@ def test_generate_endpoint_parser_multi_param(addargument):
         mock.call('--param2', choices=['a', 'b', 'c'],
                   help="Second param", nargs='+')
     ])
+
+
+@mock.patch('argparse.ArgumentParser.add_argument')
+def test_generate_endpoint_parser_resource(addargument):
+    """Generate a parser from endpoint metadata - API resource"""
+    name = 'get-stuff'
+    metadata = {
+        'path': 'stuff',
+        'method': 'GET',
+        'help': "Gets stuff",
+        'resource': {
+            'help': "API resource",
+            'type': int,
+        },
+        'params': {},
+    }
+    parser = ArgumentParser()
+    subparsers = parser.add_subparsers()
+
+    generate_endpoint_parser(subparsers, name, metadata)
+
+    addargument.assert_has_calls([
+        # first helper for the main parser
+        mock.call('-h', '--help', action='help',
+                  default=mock.ANY, help=mock.ANY),
+
+        # second helper for the 'put-stuff' subparser
+        mock.call('-h', '--help', action='help',
+                  default=mock.ANY, help=mock.ANY),
+
+        # resource
+        mock.call('resource', help="API resource", type=int)
+    ])


### PR DESCRIPTION
Relates to https://github.com/shaarli/Shaarli/pull/840
See https://shaarli.github.io/api-documentation/#links-link-put

Added:
- PUT /api/v1/links/<LINK_ID> to update an existing link/note
- Add support for API path resources to endpoint parser generation