### PR TITLE
Request for comments: add media/page archiving capabilities to the Python Shaarli client

### DIFF
--- a/media-archiver.sh
+++ b/media-archiver.sh
@@ -48,18 +48,16 @@ exportfile="${outdir}/shaarli.export" # Write plain text
 logfile="${outdir}/youtube-dl.log" # Archiver log file location
 blacklist="${outdir}/youtube-dl.blacklist" # URLs listed there will not be downloaded
 youtube_dl_extra_options="--no-playlist --add-metadata" # Extra options for youtube-dl
+wait_time="1" # time to wait between requests
 
 ###################
 
-#function install {
-#python3 -m venv venv
-#source venv/bin/activate
-## install from source
-#python setup.py install
-## install from pip (disabled)
-##pip install shaarli-client
-#pip freeze
-#}
+function _install {
+python3 -m venv venv
+source venv/bin/activate
+python setup.py install
+pip freeze
+}
 
 #################
 
@@ -87,6 +85,7 @@ function _download_music_links {
 			"$url" \
 			--output 'music/%(title)s-%(extractor)s-%(id)s.%(ext)s' 2>&1 | tee -a "$logfile"
 		fi
+		sleep "$wait_time"
 	done
 }
 
@@ -105,6 +104,7 @@ function _warn_on_errors {
 if [ ! -d "$outdir" ]; then mkdir -p "$outdir"; fi
 date | tee -a "$logfile"
 
+_install
 _export_music_links
 _download_music_links
 _warn_on_errors

--- a/media-archiver.sh
+++ b/media-archiver.sh
@@ -81,6 +81,7 @@ function _download_music_links {
 			youtube-dl \
 			$youtube_dl_extra_options \
 			--extract-audio \
+			--audio-format best \
 			--download-archive music/youtube-dl.archive \
 			"$url" \
 			--output 'music/%(title)s-%(extractor)s-%(id)s.%(ext)s' 2>&1 | tee -a "$logfile"

--- a/media-archiver.sh
+++ b/media-archiver.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# Description: export links tagged 'music' from a shaarli instance, download them with youtube-dl
+# Status: proof-of-concept/draft
+# Source: https://github.com/nodiscc/python-shaarli-client
+# License: MIT
+set -e
+
+##################
+# TODO
+
+#Desired features:
+
+# * Command line interface
+# * export: Export shaares from a shaarli instance to plain text
+# * export: Filter shaares by tag/private setting/fulltext search/date...
+# * export: Export shaares to other formats (HTML? + browseable/filterable index + list of tags? Markdown?....) http://work.krasimirtsonev.com/git/bubblejs/example/# https://github.com/nodiscc/awesome-selfhosted/blob/yaml/html/filtering.js
+# * youtube-dl: Extract audio content using youtube-dl
+# * youtube-dl: Extract video content using youtube-dl
+# * youtube-dl: implementation: import youtube-dl as a library? or use subprocess calls?
+# * youtube-dl: Customizable extraction options (path, file naming, format...) - currently everything is hardcoded.
+# * youtube-dl: Blacklist items from being downloaded through a blacklist or special tags
+# * youtube-dl: Ignore already downloaded items, or force re-downloading them
+# * youtube-dl: Log success and failures
+
+#Might be wanted someday:
+
+# * youtube-dl: Separate public/private link output directories
+# * youtube-dl: don't use --no-playlist when link matches a pattern/tag (album, playlist...)
+# * youtube-dl: Convert multimedia files to other formats
+# * youtube-dl: Instead of downloading items, create an m3U playlist for media, linking to the media url reported by youtube-dl --get-url
+# * webpages: Download webpage contents
+# * webpages: Low priority for me, https://github.com/pirate/bookmark-archiver seems to do a good job
+# * webpages: Delegate to another lib/program? httrack, wget, pavuk, scrapy, https://github.com/lorien/grab?
+# * webpages: Use special downloaders/extractors when link matches a pattern/tag (git clone, git clone mediawiki://, https://github.com/beaufour/flickr-download, https://github.com/bdoms/tumblr_backup, https://github.com/Szero/imgur-album-downloader...)
+# * webpages: Recursively download certain files (htm,html,zip,png,jpg,wav,ogg,mp3,flac,avi,webm,ogv,mp4,pdf...) when link matches a pattern/tag. Ability to restric to the same sub/domain
+# * webpages: filter ads from downloaded webpages (dnsmasq? host files: https://github.com/nodiscc/superhosts, filterlists.com)
+# * webpages: download links in descriptions
+# * webpages: add "readability" features: cleanup pages from useless elements (https://github.com/wallabag/wallabag/tree/master/inc/3rdparty/site_config) - less needed thanks to firefox reading mode, the only benefit would be lower disk usage
+# * export: append archive.org URL to HTML index
+# * other: download magnet links
+# * other: upload to archive.org (public links only) - curl https://web.archive.org/save/$url ; https://github.com/Famicoman/ia-ul-from-youtubedl
+
+###################
+# configuration
+
+outdir="music" # Output directory for downloaded files
+exportfile="${outdir}/shaarli.export" # Write plain text 
+logfile="${outdir}/youtube-dl.log" # Archiver log file location
+blacklist="${outdir}/youtube-dl.blacklist" # URLs listed there will not be downloaded
+youtube_dl_extra_options="--no-playlist --add-metadata" # Extra options for youtube-dl
+
+###################
+
+#function install {
+#python3 -m venv venv
+#source venv/bin/activate
+## install from source
+#python setup.py install
+## install from pip (disabled)
+##pip install shaarli-client
+#pip freeze
+#}
+
+#################
+
+function _export_music_links {
+	# get links tagged 'music' and write them to a file
+	# TODO python-shaarli-client --format text option does not work
+	# dirty workaround using jq json parser
+	shaarli get-links --limit 100000 --searchtags music | \
+		jq '.[] | {url: .url} | .[]' | sed 's/\"//g' >| "$exportfile"
+}
+
+function _download_music_links {
+	# Download
+	cat "$exportfile" | while read -r url; do
+		echo "[archiver] $url" | tee -a "$logfile"
+		# check URL against blacklist
+		if egrep "^${url}$" "$blacklist"; then
+			echo "[archiver] URL is in blacklist, skipping"
+		else
+			# download media with youtube-dl
+			youtube-dl \
+			$youtube_dl_extra_options \
+			--extract-audio \
+			--download-archive music/youtube-dl.archive \
+			"$url" \
+			--output 'music/%(title)s-%(extractor)s-%(id)s.%(ext)s' 2>&1 | tee -a "$logfile"
+		fi
+	done
+}
+
+function _warn_on_errors {
+	ytdl_errors=$(grep ERROR "$logfile"  |sort --unique)
+	if [ ! "$ytdlerrors" == "" ]; then
+		errorcount=$(echo "$ytdl_errors" | wc -l)
+		echo "WARNING: there are $errorcount errors in $logfile:"
+		echo "$ytdl_errors"
+	fi
+}
+
+#############
+# main loop
+
+if [ ! -d "$outdir" ]; then mkdir -p "$outdir"; fi
+date | tee -a "$logfile"
+
+_export_music_links
+_download_music_links
+_warn_on_errors


### PR DESCRIPTION
Hi, this is not intended to be merged.

I attached my current quick & dirty script to archive music from an export of my Shaarli instance. It's just a bash script, as I needed it quick. Currently it downloads music, which is what I needed. I'd like to rewrite it in Python, with well thought-out integration with the official client. Consider this as a proof of concept for a rewrite of https://github.com/nodiscc/shaarchiver

I'd like some input on **how this would be best achieved**:

 * How much code separation from the main client? How to properly implement it?
   * Add a separate `entry_point` to setuptools?
   * Add a --archive-media flag to `shaarli`?
   * Add an `actions =` option in config file? Add extractor configuration there?
   * Write a totally separate client and import shaarli-client as a library?

**Some notes:**

 * The original Shaarli feature request for archiving shaares _contents_ is https://github.com/shaarli/Shaarli/issues/318  
 * There's a brief discussion about content extraction for the python client at https://github.com/shaarli/Shaarli/issues/745  
 * In https://github.com/shaarli/Shaarli/issues/106#issuecomment-74980648 it was suggested that multimedia/page content archiving/mirroring could be added directly as a Shaarli plugin. I think both a CLI archiving tool and a Shaarli plugin have their place (eg. I want to run the archive on my laptop, I don't want my webserver/PHP stack to `exec()` call youtube-dl, I have a shared host without youtube-dl/wget/... support...)  
 * There will inevitably be some feature creep, as there are many use cases for web scraping and web content download in general - which is why **I'm dubious about direct integration in the official API client**. In the first time I intend to focus on 1. downloading multimedia content as it frequently disappears without notice 2. generating a friendly offline export of my shaares.  
* `--format text` is broken for me (invalid option --format). I'll investigate that.

To get a clearer picture, I added a list of current shaarchiver features, as well as features that might reasonably be requested, to the script header. [Have a look](https://github.com/nodiscc/python-shaarli-client/blob/media-archiver/media-archiver.sh)


With that mind, what is the best way to start implementing an archiving tool around the API? (@virtualtam this is for you :) I'd rather not add bloat to the shiny new API client - I think it should stay a clean, reference client. On the other hand well integrated actions/modules would be interesting)

Once I have a clearer picture I will start working on a basic implementation, and might as well ping people who were interested in a Shaarli archiving tool.

Again there is no rush :) ETA year 2018. I'd like to work on polishing the API client first, add some tests, etc.

Edits:

 - This project could be useful as an inspiration: https://github.com/pirate/bookmark-archiver/issues/3
