### PR TITLE
Add output file (--outfile) command line argument

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,4 @@ install:
   - pip install tox
 script:
   - tox
+

--- a/docs/user/usage.rst
+++ b/docs/user/usage.rst
@@ -31,8 +31,10 @@ The ``-h`` and ``--help`` flags allow to display help for any command or sub-com
      -u URL, --url URL     Shaarli instance URL
      -s SECRET, --secret SECRET
                            API secret
-     --format {json,pprint,text}
+     -f --format {json,pprint,text}
                            Output formatting
+     -o --outfile FILENAME
+                           File to save the program output to
 
 
 .. code-block:: bash

--- a/shaarli_client/client/v1.py
+++ b/shaarli_client/client/v1.py
@@ -4,6 +4,7 @@ import time
 from argparse import Action, ArgumentTypeError
 
 import requests
+
 from requests_jwt import JWTAuth
 
 

--- a/shaarli_client/client/v1.py
+++ b/shaarli_client/client/v1.py
@@ -4,7 +4,6 @@ import time
 from argparse import Action, ArgumentTypeError
 
 import requests
-
 from requests_jwt import JWTAuth
 
 

--- a/shaarli_client/main.py
+++ b/shaarli_client/main.py
@@ -1,12 +1,11 @@
 """shaarli-client main CLI entrypoint"""
-import json
 import logging
 import sys
 from argparse import ArgumentParser
 
 from .client import ShaarliV1Client
 from .config import InvalidConfiguration, get_credentials
-from .utils import generate_all_endpoints_parsers
+from .utils import format_response, generate_all_endpoints_parsers, write_output
 
 
 def main():
@@ -33,10 +32,16 @@ def main():
         help="API secret"
     )
     parser.add_argument(
+        '-f',
         '--format',
         choices=['json', 'pprint', 'text'],
         default='pprint',
         help="Output formatting"
+    )
+    parser.add_argument(
+        '-o',
+        '--outfile',
+        help="File to save the program output to"
     )
 
     subparsers = parser.add_subparsers(
@@ -59,9 +64,8 @@ def main():
         parser.print_help()
         sys.exit(1)
 
-    if args.format == 'json':
-        print(response.json())
-    elif args.format == 'pprint':
-        print(json.dumps(response.json(), sort_keys=True, indent=4))
-    elif args.format == 'text':
-        print(response.text)
+    output = format_response(args.format, response)
+    if not args.outfile:
+        print(output)
+    else:
+        write_output(args.outfile, output)

--- a/shaarli_client/utils.py
+++ b/shaarli_client/utils.py
@@ -1,4 +1,5 @@
 """Utilities"""
+import json
 
 
 def generate_endpoint_parser(subparsers, ep_name, ep_metadata):
@@ -21,3 +22,25 @@ def generate_all_endpoints_parsers(subparsers, endpoints):
     """Generate all endpoints' subparsers from an endpoints dict"""
     for ep_name, ep_metadata in endpoints.items():
         generate_endpoint_parser(subparsers, ep_name, ep_metadata)
+
+
+def format_response(output_format, response):
+    """Format the API response to the desired output format"""
+    if output_format == 'json':
+        return response.json()
+    elif output_format == 'pprint':
+        return json.dumps(response.json(), sort_keys=True, indent=4)
+    elif output_format == 'text':
+        return response.text
+    else:
+        raise ValueError("%s is not a supported format." % output_format)
+
+
+def write_output(filename, output):
+    """Write the program output to a file"""
+    try:
+        with open(filename, 'w') as outfile_handler:
+            outfile_handler.write(output)
+            outfile_handler.close()
+    except OSError:
+        raise OSError("Unable to write output file %s" % filename)

--- a/shaarli_client/utils.py
+++ b/shaarli_client/utils.py
@@ -32,8 +32,7 @@ def format_response(output_format, response):
         return json.dumps(response.json(), sort_keys=True, indent=4)
     elif output_format == 'text':
         return response.text
-    else:
-        raise ValueError("%s is not a supported format." % output_format)
+    raise ValueError("%s is not a supported format." % output_format)
 
 
 def write_output(filename, output):

--- a/shaarli_client/utils.py
+++ b/shaarli_client/utils.py
@@ -40,6 +40,5 @@ def write_output(filename, output):
     try:
         with open(filename, 'w') as outfile_handler:
             outfile_handler.write(output)
-            outfile_handler.close()
     except OSError:
         raise OSError("Unable to write output file %s" % filename)

--- a/tests/client/test_v1.py
+++ b/tests/client/test_v1.py
@@ -4,11 +4,11 @@ from argparse import ArgumentTypeError, Namespace
 from unittest import mock
 
 import pytest
+
 from requests.exceptions import InvalidSchema, MissingSchema
 
 from shaarli_client.client.v1 import (InvalidEndpointParameters,
-                                      ShaarliV1Client,
-                                      check_positive_integer)
+                                      ShaarliV1Client, check_positive_integer)
 
 SHAARLI_URL = 'http://domain.tld/shaarli'
 SHAARLI_SECRET = 's3kr37!'

--- a/tests/client/test_v1.py
+++ b/tests/client/test_v1.py
@@ -4,9 +4,7 @@ from argparse import ArgumentTypeError, Namespace
 from unittest import mock
 
 import pytest
-
 from requests.exceptions import InvalidSchema, MissingSchema
-
 from shaarli_client.client.v1 import (InvalidEndpointParameters,
                                       ShaarliV1Client, check_positive_integer)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,6 @@ from argparse import Namespace
 from configparser import ConfigParser
 
 import pytest
-
 from shaarli_client.config import InvalidConfiguration, get_credentials
 
 SHAARLI_URL = 'http://shaar.li'


### PR DESCRIPTION
    add --outfile optional parameter: specify a filename to write the API request result to
     * by default output is redirected to standard output
     * add -f and -o short options (format/output)
     * overwrite output file on each run, don't append (appending will cause a malformed json file)
     * move json import to utils.py
     * move response formatting and output to separate functions
     * styling fixes, tab to spaces, alignment, sort imports
     * use a context manager to handle writing output file
     * Handle OSError execptions
