### PR TITLE
Add --outfile optional parameter

### DIFF
--- a/docs/user/usage.rst
+++ b/docs/user/usage.rst
@@ -31,8 +31,10 @@ The ``-h`` and ``--help`` flags allow to display help for any command or sub-com
      -u URL, --url URL     Shaarli instance URL
      -s SECRET, --secret SECRET
                            API secret
-     --format {json,pprint,text}
+     -f --format {json,pprint,text}
                            Output formatting
+     -o --outfile FILENAME
+                           File to save the program output to
 
 
 .. code-block:: bash

--- a/shaarli_client/main.py
+++ b/shaarli_client/main.py
@@ -1,12 +1,11 @@
 """shaarli-client main CLI entrypoint"""
-import json
 import logging
 import sys
 from argparse import ArgumentParser
 
 from .client import ShaarliV1Client
 from .config import InvalidConfiguration, get_credentials
-from .utils import generate_all_endpoints_parsers
+from .utils import format_response, generate_all_endpoints_parsers, write_output
 
 
 def main():
@@ -33,10 +32,16 @@ def main():
         help="API secret"
     )
     parser.add_argument(
+        '-f',
         '--format',
         choices=['json', 'pprint', 'text'],
         default='pprint',
         help="Output formatting"
+    )
+    parser.add_argument(
+        '-o',
+        '--outfile',
+        help="File to save the program output to"
     )
 
     subparsers = parser.add_subparsers(
@@ -59,9 +64,8 @@ def main():
         parser.print_help()
         sys.exit(1)
 
-    if args.format == 'json':
-        print(response.json())
-    elif args.format == 'pprint':
-        print(json.dumps(response.json(), sort_keys=True, indent=4))
-    elif args.format == 'text':
-        print(response.text)
+    output = format_response(args.format, response)
+    if not args.outfile:
+        print(output)
+    else:
+        write_output(args.outfile, output)

--- a/shaarli_client/utils.py
+++ b/shaarli_client/utils.py
@@ -1,4 +1,5 @@
 """Utilities"""
+import json
 
 
 def generate_endpoint_parser(subparsers, ep_name, ep_metadata):
@@ -21,3 +22,23 @@ def generate_all_endpoints_parsers(subparsers, endpoints):
     """Generate all endpoints' subparsers from an endpoints dict"""
     for ep_name, ep_metadata in endpoints.items():
         generate_endpoint_parser(subparsers, ep_name, ep_metadata)
+
+
+def format_response(output_format, response):
+    """Format the API response to the desired output format"""
+    if output_format == 'json':
+        return json.dumps(response.json())
+    elif output_format == 'pprint':
+        return json.dumps(response.json(), sort_keys=True, indent=4)
+    elif output_format == 'text':
+        return response.text
+    raise ValueError("%s is not a supported format." % output_format)
+
+
+def write_output(filename, output):
+    """Write the program output to a file"""
+    try:
+        with open(filename, 'w') as outfile_handler:
+            outfile_handler.write(output)
+    except OSError:
+        raise OSError("Unable to write output file %s" % filename)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,12 @@
 """Tests for Shaarli client utilities"""
 # pylint: disable=invalid-name
+import json
 from argparse import ArgumentParser
 from unittest import mock
 
-from shaarli_client.utils import generate_endpoint_parser
+from requests import Response
+
+from shaarli_client.utils import format_response, generate_endpoint_parser
 
 
 @mock.patch('argparse.ArgumentParser.add_argument')
@@ -139,3 +142,43 @@ def test_generate_endpoint_parser_resource(addargument):
         # resource
         mock.call('resource', help="API resource", type=int)
     ])
+
+
+def test_format_response_text():
+    """Format a Requests Response object to plain text"""
+    response = Response()
+    response.__setstate__({
+        '_content': b'{"global_counter":3251,'
+                    b'"private_counter":1,'
+                    b'"settings":{"title":"Yay!","header_link":"?",'
+                    b'"timezone":"UTC",'
+                    b'"enabled_plugins":["qrcode","token"],'
+                    b'"default_private_links":false}}',
+    })
+
+    assert isinstance(response.text, str)
+    assert response.text == '{"global_counter":3251,' \
+                            '"private_counter":1,' \
+                            '"settings":{"title":"Yay!","header_link":"?",' \
+                            '"timezone":"UTC",' \
+                            '"enabled_plugins":["qrcode","token"],' \
+                            '"default_private_links":false}}'
+
+
+def test_format_response_json():
+    """Format a Requests Response object to JSON"""
+    response = Response()
+    response.__setstate__({
+        '_content': b'{"global_counter":3251,'
+                    b'"private_counter":1,'
+                    b'"settings":{"title":"Yay!","header_link":"?",'
+                    b'"timezone":"UTC",'
+                    b'"enabled_plugins":["qrcode","token"],'
+                    b'"default_private_links":false}}',
+    })
+
+    assert isinstance(response.json(), dict)
+
+    # Ensure valid JSON is returned after formatting
+    assert json.loads(format_response('json', response))
+    assert json.loads(format_response('pprint', response))


### PR DESCRIPTION
This is a rebased and squashed version of #23 by @nodiscc, with additional test coverage

Specify a filename to write the API request result to:

 * by default output is redirected to standard output
 * add -f and -o short options (format/output)
 * overwrite output file on each run, don't append (appending will cause a malformed json file)
 * move json import to utils.py
 * move response formatting and output to separate functions
 * use a context manager to handle writing output file
 * Handle OSError execptions