### PR TITLE
CLI: handle empty response body before formatting

### DIFF
--- a/shaarli_client/utils.py
+++ b/shaarli_client/utils.py
@@ -26,13 +26,18 @@ def generate_all_endpoints_parsers(subparsers, endpoints):
 
 def format_response(output_format, response):
     """Format the API response to the desired output format"""
-    if output_format == 'json':
-        return json.dumps(response.json())
+    if not response.content:
+        formatted = ''
+    elif output_format == 'json':
+        formatted = json.dumps(response.json())
     elif output_format == 'pprint':
-        return json.dumps(response.json(), sort_keys=True, indent=4)
+        formatted = json.dumps(response.json(), sort_keys=True, indent=4)
     elif output_format == 'text':
-        return response.text
-    raise ValueError("%s is not a supported format." % output_format)
+        formatted = response.text
+    else:
+        raise ValueError("%s is not a supported format." % output_format)
+
+    return formatted
 
 
 def write_output(filename, output):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,7 @@ import json
 from argparse import ArgumentParser
 from unittest import mock
 
+import pytest
 from requests import Response
 
 from shaarli_client.utils import format_response, generate_endpoint_parser
@@ -142,6 +143,24 @@ def test_generate_endpoint_parser_resource(addargument):
         # resource
         mock.call('resource', help="API resource", type=int)
     ])
+
+
+def test_format_response_unsupported_format():
+    """Attempt to use an unsupported formatting flag"""
+    response = Response()
+    response.__setstate__({'_content': b'{"field":"value"}'})
+
+    with pytest.raises(ValueError) as err:
+        format_response('xml', response)
+
+    assert "not a supported format" in str(err.value)
+
+
+@pytest.mark.parametrize('output_format', ['json', 'pprint', 'text'])
+def test_format_response_empty_body(output_format):
+    """Format a Requests Response object with no body"""
+    response = Response()
+    assert format_response(output_format, response) == ''
 
 
 def test_format_response_text():


### PR DESCRIPTION
Fixes https://github.com/shaarli/python-shaarli-client/issues/28