### PR TITLE
fix: typo in POST /link endpoint

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,6 +26,7 @@ The format is based on `Keep a Changelog`_ and this project adheres to
 **Fixed:**
 
 * Use requests-jwt < 0.5
+* Fix `POST /link` endpoint name
 
 
 `v0.2.0 <https://github.com/shaarli/python-shaarli-client/releases/tag/v0.2.0>`_ - 2017-04-09

--- a/shaarli_client/client/v1.py
+++ b/shaarli_client/client/v1.py
@@ -277,7 +277,7 @@ class ShaarliV1Client:
 
     def post_link(self, params):
         """Create a new link or note"""
-        self._check_endpoint_params('post-links', params)
+        self._check_endpoint_params('post-link', params)
         return self._request('POST', 'links', params)
 
     def put_link(self, resource, params):


### PR DESCRIPTION
Fixes https://github.com/shaarli/python-shaarli-client/issues/36