### PR TITLE
WIP: implement audio download functionality

### DIFF
--- a/shaarli_client/main.py
+++ b/shaarli_client/main.py
@@ -5,16 +5,25 @@ from argparse import ArgumentParser
 
 from .client import ShaarliV1Client
 from .config import InvalidConfiguration, get_credentials
-from .utils import format_response, generate_all_endpoints_parsers, write_output
+from .utils import download_audio, format_response, generate_all_endpoints_parsers, write_output
 
 
 def main():
     """Main CLI entrypoint"""
+    # https://docs.python.org/3/library/argparse.html
     parser = ArgumentParser()
     parser.add_argument(
         '-c',
         '--config',
         help="Configuration file"
+    )
+    parser.add_argument(
+        '--download-audio',
+        action='store_const',
+        default=False,
+        const=True,
+        dest="downloadaudio",
+        help="Download audio from returned links using youtube-dl"
     )
     parser.add_argument(
         '-i',
@@ -69,3 +78,6 @@ def main():
         print(output)
     else:
         write_output(args.outfile, output)
+
+    if args.downloadaudio:
+        download_audio(response)

--- a/shaarli_client/main.py
+++ b/shaarli_client/main.py
@@ -5,7 +5,8 @@ from argparse import ArgumentParser
 
 from .client import ShaarliV1Client
 from .config import InvalidConfiguration, get_credentials
-from .utils import download_audio, format_response, generate_all_endpoints_parsers, write_output
+from .utils import (download_audio, format_response,
+                    generate_all_endpoints_parsers, write_output)
 
 
 def main():

--- a/shaarli_client/utils.py
+++ b/shaarli_client/utils.py
@@ -1,5 +1,6 @@
 """Utilities"""
 import json
+import subprocess
 
 
 def generate_endpoint_parser(subparsers, ep_name, ep_metadata):
@@ -38,6 +39,19 @@ def format_response(output_format, response):
         raise ValueError("%s is not a supported format." % output_format)
 
     return formatted
+
+
+def download_audio(response):
+    """Download and extract audio from returned links using youtube-dl"""
+    data=json.loads(format_response('json', response))
+    print(type(data))
+    numlinks = len(data)
+    index = 0
+    while index < numlinks:
+        url = data[index]['url']
+        print("[shaarli] INFO: downloading %s" % url)
+        subprocess.run(['youtube-dl', '--extract-audio', '--audio-format', 'mp3', url])
+        index += 1
 
 
 def write_output(filename, output):

--- a/shaarli_client/utils.py
+++ b/shaarli_client/utils.py
@@ -43,14 +43,16 @@ def format_response(output_format, response):
 
 def download_audio(response):
     """Download and extract audio from returned links using youtube-dl"""
-    data=json.loads(format_response('json', response))
+    data = json.loads(format_response('json', response))
     print(type(data))
     numlinks = len(data)
     index = 0
     while index < numlinks:
         url = data[index]['url']
         print("[shaarli] INFO: downloading %s" % url)
-        subprocess.run(['youtube-dl', '--extract-audio', '--audio-format', 'mp3', url])
+        subprocess.run(['youtube-dl',
+                        '--extract-audio', '--audio-format', 'mp3',
+                        url])
         index += 1
 
 


### PR DESCRIPTION
 - passing the --download-audio parameter will run youtube-dl to download audio from returned links
 - example: shaarli --download-audio get-links --searchtags=music --limit=all
 - Requires youtube-dl

sort imports, fix pycodestyle warnings, Ref. #24 

TODO:

- [ ] Download log
- [ ] Error log
- [ ] Check youtube-dl availability
- [ ] update documentation
- [ ] only allow --download-audio for `get-links` subcommand, error/ignore otherwise
- [ ] configuration from CLI parameters + configuration file
  - [ ] output directory
  - [ ]  audio format
  - [ ] youtube-dl path
  - [ ] youtube-dl custom options
  - [ ] URL blacklist
  - [ ] Abort/continue on errors

