### PR TITLE
fix test_get_info_invalid_uri test on python 3.5 and 3.6

### DIFF
--- a/tests/client/test_v1.py
+++ b/tests/client/test_v1.py
@@ -4,7 +4,7 @@ from argparse import ArgumentTypeError, Namespace
 from unittest import mock
 
 import pytest
-from requests.exceptions import InvalidSchema, MissingSchema
+from requests.exceptions import InvalidSchema, InvalidURL, MissingSchema
 
 from shaarli_client.client.v1 import (InvalidEndpointParameters,
                                       ShaarliV1Client, check_positive_integer)
@@ -126,7 +126,7 @@ def test_get_info_uri(request):
 
 @pytest.mark.parametrize('uri, klass, msg', [
     ('shaarli', MissingSchema, "No schema supplied"),
-    ('http:/shaarli', MissingSchema, "No schema supplied"),
+    ('http:/shaarli', InvalidURL, "No host supplied"),
     ('htp://shaarli', InvalidSchema, "No connection adapters"),
 ])
 def test_get_info_invalid_uri(uri, klass, msg):


### PR DESCRIPTION
However, this causes python 3.4 tests to fail:
 - on python 3.4 the returned message is `No schema supplied`, the exception class is `MissingSchema,`
 - on python 3.5 and 3.6 the message is `No host supplied`, the exception class is `InvalidURL`