### PR TITLE
Add support for Python 3.7, 3.8 and 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,29 @@
+---
 language: python
+
 cache:
   directories:
     - $HOME/.cache/pip
+
 matrix:
   include:
-    - python: 3.7
+    - python: 3.9
       env: TOXENV=docs
+
+    - python: 3.9
+      env: TOXENV=py39
+
+    - python: 3.8
+      env: TOXENV=py38
+
+    - python: 3.7
+      env: TOXENV=py37
+
     - python: 3.6
       env: TOXENV=py36
+
 install:
   - pip install -r requirements/ci.txt
+
 script:
   - tox

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,8 +1,8 @@
-coverage==4.5.1
-isort==4.3.4
-pycodestyle==2.4.0
-pydocstyle==2.1.1
-pylint==1.9.1
-pytest==3.6.0
-pytest-cov==2.5.1
-pytest-pylint==0.9.0
+coverage==5.5
+isort==5.8.0
+pycodestyle==2.7.0
+pydocstyle==6.0.0
+pylint==2.7.4
+pytest==6.2.3
+pytest-cov==2.11.1
+pytest-pylint==0.18.0

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,9 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: Utilities',
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py3{6},docs
+envlist=py3{6,7,8,9},docs
 skip_missing_interpreters=True
 
 [testenv]


### PR DESCRIPTION
Relates to https://github.com/shaarli/python-shaarli-client/pull/52#discussion_r593754202

### Added
- Update package identifiers to explicit Python 3.7, 3.8 and 3.9 support

### Changed
- Update the Tox environment list
- Update the Travis test matrix to add new environments
- Update the Travis test matrix to build docs using Python 3.9