### PR TITLE
Refactor JWT authentication to avoid depending on the unmaintained 'requests-jwt' library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,9 +40,8 @@ setup(
         ],
     },
     install_requires=[
-        'requests >= 2.10',
-        'requests-jwt >= 0.4, < 0.5',
-        'pyjwt == 1.7.1'
+        'requests >= 2.25',
+        'pyjwt == 2.0.1'
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/tests/client/test_v1.py
+++ b/tests/client/test_v1.py
@@ -119,7 +119,7 @@ def test_get_info_uri(request):
     request.assert_called_once_with(
         'GET',
         '%s/api/v1/info' % SHAARLI_URL,
-        auth=mock.ANY,
+        headers=mock.ANY,
         verify=True,
         params={}
     )
@@ -145,7 +145,7 @@ def test_get_links_uri(request):
     request.assert_called_once_with(
         'GET',
         '%s/api/v1/links' % SHAARLI_URL,
-        auth=mock.ANY,
+        headers=mock.ANY,
         verify=True,
         params={}
     )
@@ -187,7 +187,7 @@ def test_post_links_uri(request):
     request.assert_called_once_with(
         'POST',
         '%s/api/v1/links' % SHAARLI_URL,
-        auth=mock.ANY,
+        headers=mock.ANY,
         json={}
     )
 
@@ -229,7 +229,7 @@ def test_put_links_uri(request):
     request.assert_called_once_with(
         'PUT',
         '%s/api/v1/links/12' % SHAARLI_URL,
-        auth=mock.ANY,
+        headers=mock.ANY,
         json={}
     )
 
@@ -288,7 +288,7 @@ def test_get_tags_uri(request):
     request.assert_called_once_with(
         'GET',
         '%s/api/v1/tags' % SHAARLI_URL,
-        auth=mock.ANY,
+        headers=mock.ANY,
         verify=True,
         params={}
     )
@@ -301,7 +301,7 @@ def test_put_tags_uri(request):
     request.assert_called_once_with(
         'PUT',
         '%s/api/v1/tags/some-tag' % SHAARLI_URL,
-        auth=mock.ANY,
+        headers=mock.ANY,
         json={}
     )
 
@@ -340,7 +340,7 @@ def test_delete_tags_uri(request):
     request.assert_called_once_with(
         'DELETE',
         '%s/api/v1/tags/some-tag' % SHAARLI_URL,
-        auth=mock.ANY,
+        headers=mock.ANY,
         json={}
     )
 


### PR DESCRIPTION
Depends on #53 (updates test environments)
Relates to https://github.com/shaarli/python-shaarli-client/pull/52#discussion_r594520504
See https://github.com/tgs/requests-jwt/commit/0c99f90393cce10df8782f5de56ec40cf616764c
Fixes #51

### Changed
- Refactor the API client's `requests` wrapper to set the HTTP authorization header using PyJWT

### Removed
- Remove unmaintained `requests-jwt` dependency