### PR TITLE
doc: developer: releasing: update test.pypi.org usage instructions

### DIFF
--- a/docs/developer/pypirc
+++ b/docs/developer/pypirc
@@ -4,10 +4,10 @@ index-servers=
     testpypi
 
 [pypi]
-repository = https://pypi.python.org/pypi
+repository = https://pypi.python.org/legacy/
 username = <PyPI username>
 
 [testpypi]
-repository = https://testpypi.python.org/pypi
+repository = https://test.pypi.org/legacy/
 username = <TestPyPI username>
 password = <TestPyPI password>

--- a/docs/developer/releasing.rst
+++ b/docs/developer/releasing.rst
@@ -88,6 +88,6 @@ PyPI
 .. _Packaging and Distributing Projects: https://packaging.python.org/distributing/
 .. _PyPI: https://pypi.python.org/pypi
 .. _Python Packaging User Guide: https://packaging.python.org
-.. _TestPyPI: https://testpypi.python.org/pypi
-.. _TestPyPI Configuration: https://wiki.python.org/moin/TestPyPI
+.. _TestPyPI: https://test.pypi.org/
+.. _TestPyPI Configuration: https://packaging.python.org/en/latest/guides/using-testpypi/
 .. _twine: https://pypi.python.org/pypi/twine


### PR DESCRIPTION
```
HTTPError: 410 Client Error: This API has moved to https://test.pypi.org/legacy/. See TODO for more information. for url: https://test.pypi.org/pypi
```

/cc @virtualtam @ArthurHoaro 