### PR TITLE
release v0.5.0

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,7 +10,7 @@ The format is based on `Keep a Changelog`_ and this project adheres to
 .. _Semantic Versioning: http://semver.org/
 
 
-`v0.5.0 <https://github.com/shaarli/python-shaarli-client/releases/tag/v0.5.0>`_ - 2022-05-27
+`v0.5.0 <https://github.com/shaarli/python-shaarli-client/releases/tag/v0.5.0>`_ - 2022-07-26
 ---------------------------------------------------------------------------------------------
 
 **Added:**

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,28 @@ The format is based on `Keep a Changelog`_ and this project adheres to
 .. _Semantic Versioning: http://semver.org/
 
 
+`v0.5.0 <https://github.com/shaarli/python-shaarli-client/releases/tag/v0.5.0>`_ - 2022-05-27
+---------------------------------------------------------------------------------------------
+
+**Added:**
+
+* Add ``delete-link`` command (delete a link by ID)
+
+
+**Changed:**
+
+* Update test tooling and documentation
+
+
+**Fixed:**
+
+* Fix ``--insecure`` option for non-GET requests
+
+**Security:**
+
+* Update `PyJWT <https://pypi.org/project/PyJWT/>`_ to 2.4.0
+
+
 `v0.4.1 <https://github.com/shaarli/python-shaarli-client/releases/tag/v0.4.1>`_ - 2021-05-13
 ---------------------------------------------------------------------------------------------
 

--- a/shaarli_client/__init__.py
+++ b/shaarli_client/__init__.py
@@ -1,5 +1,5 @@
 """shaarli-client"""
 __title__ = 'shaarli_client'
 __brief__ = 'CLI to interact with a Shaarli instance'
-__version__ = '0.4.1'
+__version__ = '0.5.0'
 __author__ = 'The Shaarli Community'


### PR DESCRIPTION
A new release should be tagged and [created](https://github.com/shaarli/python-shaarli-client/releases) after merging this. I can't upload the new package to the test Pypi repository, I think @virtualtam has to do it:

```
$ export IDENTITY=6CA755D0D14254D79BA32DEE067FC4266A4B6909
$ make test_release 
[...]
Uploading distributions to https://test.pypi.org/legacy/
Signing shaarli_client-0.5.0-py3-none-any.whl
Uploading shaarli_client-0.5.0-py3-none-any.whl
100%|███| 13.8k/13.8k [00:01<00:00, 13.6kB/s]
HTTPError: 403 Client Error: The user 'nodiscc' isn't allowed to upload to project 'shaarli-client'. See https://test.pypi.org/help/#project-name for more information. for url: https://test.pypi.org/legacy/
make: *** [Makefile:39 : test_release] Erreur 1
```

/cc @ArthurHoaro 