### PR TITLE
docs/developer/releasing.rst: update URL for pypi.org

### DIFF
--- a/docs/developer/pypirc
+++ b/docs/developer/pypirc
@@ -4,7 +4,7 @@ index-servers=
     testpypi
 
 [pypi]
-repository = https://pypi.python.org/legacy/
+repository = https://upload.pypi.org/legacy/
 username = <PyPI username>
 
 [testpypi]

--- a/docs/developer/releasing.rst
+++ b/docs/developer/releasing.rst
@@ -86,7 +86,7 @@ PyPI
 
 
 .. _Packaging and Distributing Projects: https://packaging.python.org/distributing/
-.. _PyPI: https://pypi.python.org/pypi
+.. _PyPI: https://pypi.org/
 .. _Python Packaging User Guide: https://packaging.python.org
 .. _TestPyPI: https://test.pypi.org/
 .. _TestPyPI Configuration: https://packaging.python.org/en/latest/guides/using-testpypi/


### PR DESCRIPTION
```
UploadToDeprecatedPyPIDetected: You're trying to upload to the legacy PyPI site 'https://pypi.python.org/legacy/'. Uploading to those sites is deprecated.
 The new sites are pypi.org and test.pypi.org. Try using https://upload.pypi.org/legacy/ (or https://test.pypi.org/legacy/) to upload your packages instead. These are the default URLs for Twine now.
 More at https://packaging.python.org/guides/migrating-to-pypi-org/ .
```