### PR TITLE
doc: fix example usage/inserting newlines in descriptions

### DIFF
--- a/docs/user/usage.rst
+++ b/docs/user/usage.rst
@@ -273,11 +273,11 @@ PUT tag
 New lines/line breaks
 ~~~~~~~~~~~~~~~~~~~~~
 
-If you need to include line breaks in your descriptions, use a literal newline ``\n`` and **single quotes** around the description:
+If you need to include line breaks in your descriptions, use a literal newline ``\n`` and `$'...'` around the description:
 
 .. code-block:: bash
 
-    $ shaarli post-link --url https://example.com/ --description 'One\nword\nper\nline'.
+    $ shaarli post-link --url https://example.com/ --description $'One\nword\nper\nline'.
 
 
 NOT (minus) operator


### PR DESCRIPTION
- fixes https://github.com/shaarli/python-shaarli-client/issues/43
- ref. https://github.com/shaarli/Shaarli/issues/1360
- ref. https://stackoverflow.com/a/5295906/1484919
> Bash has support for another string syntax that supports escape sequences like \n and \t. To use it, start the string with $' and end the string with '