### PR TITLE
tools: readthedocs: fix documentation generation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,19 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+  builder: html
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+  commands:
+    - pip install sphinx-rtd-theme
+    - sphinx-build -b html -c docs/ docs/ _readthedocs/html/


### PR DESCRIPTION
- https://readthedocs.org/projects/python-shaarli-client/builds/23400602/
- The required readthedocs.yaml configuration file was not found at repository's root. Learn how to use this file in our configuration file tutorial.
- https://docs.readthedocs.io/en/stable/config-file/index.html